### PR TITLE
Make GSON ignore fields without Expose Annotations by default

### DIFF
--- a/common/src/main/java/io/github/notenoughupdates/moulconfig/managed/GsonMapper.kt
+++ b/common/src/main/java/io/github/notenoughupdates/moulconfig/managed/GsonMapper.kt
@@ -9,6 +9,7 @@ class GsonMapper<T>(val clazz: Class<T>) : DataMapper<T> {
     val gsonBuilder = GsonBuilder()
         .registerTypeAdapterFactory(PropertyTypeAdapterFactory())
         .registerTypeAdapter(ChromaColour::class.java, LegacyStringChromaColourTypeAdapter(true))
+        .excludeFieldsWithoutExposeAnnotation()
     private val gson by lazy { gsonBuilder.create() }
     override fun serialize(value: T): String {
         return gson.toJson(value)


### PR DESCRIPTION
When using a `ManagedConfig`, this allows for the inclusion of non-serializable objects (eg `Runnable` instances) in the config without any workarounds.