### PR TITLE
Fix: Color wrong value

### DIFF
--- a/common/src/main/java/io/github/notenoughupdates/moulconfig/ChromaColour.kt
+++ b/common/src/main/java/io/github/notenoughupdates/moulconfig/ChromaColour.kt
@@ -47,7 +47,7 @@ data class ChromaColour(
      * The value of [evaluateColourWithShift] at [cachedRGBHueOffset]
      */
     @Transient
-    private var cachedRGB: Int = 0
+    private var cachedRGB: Int = Color.HSBtoRGB(hue, saturation, brightness) and 0x00FFFFFF or (alpha shl 24)
 
     /**
      * The last queried value of [evaluateColourWithShift].


### PR DESCRIPTION
fixes the cachedrgb value not being initialized properly, causing colors to always be considered as black until they get updated
also made it so that it doesn't use cachedrgb in the legacy string method

this fixes chroma colors sometimes being saved as black in config