### PR TITLE
Allow for dynamic `toString` in Draggable Lists

### DIFF
--- a/common/src/main/java/io/github/notenoughupdates/moulconfig/annotations/ConfigEditorDraggableList.java
+++ b/common/src/main/java/io/github/notenoughupdates/moulconfig/annotations/ConfigEditorDraggableList.java
@@ -48,6 +48,12 @@ public @interface ConfigEditorDraggableList {
     boolean requireNonEmpty() default false;
 
     /**
+     * If true, never cache the exampleText map and
+     * always call element.toString() at render‐time.
+     */
+    boolean dynamicToString() default false;
+
+    /**
      * @return set to false to disable deleting items from the list
      */
     boolean allowDeleting() default true;

--- a/common/src/main/java/io/github/notenoughupdates/moulconfig/gui/editors/GuiOptionEditorDraggableList.java
+++ b/common/src/main/java/io/github/notenoughupdates/moulconfig/gui/editors/GuiOptionEditorDraggableList.java
@@ -29,6 +29,7 @@ import io.github.notenoughupdates.moulconfig.gui.KeyboardEvent;
 import io.github.notenoughupdates.moulconfig.gui.MouseEvent;
 import io.github.notenoughupdates.moulconfig.internal.LerpUtils;
 import io.github.notenoughupdates.moulconfig.internal.TypeUtils;
+import io.github.notenoughupdates.moulconfig.internal.Warnings;
 import io.github.notenoughupdates.moulconfig.processor.ProcessedOption;
 import kotlin.Pair;
 import lombok.var;
@@ -78,9 +79,7 @@ public class GuiOptionEditorDraggableList extends GuiOptionEditor {
         this.activeText = (List) option.get();
         this.requireNonEmpty = requireNonEmpty;
 
-        Class<?> elementType = TypeUtils.resolveRawType(
-            ((ParameterizedType) option.getType()).getActualTypeArguments()[0]
-        );
+        Class<?> elementType = TypeUtils.resolveRawType(((ParameterizedType) option.getType()).getActualTypeArguments()[0]);
 
         if (!dynamicToString && Enum.class.isAssignableFrom(elementType)) {
             @SuppressWarnings("unchecked")
@@ -108,11 +107,20 @@ public class GuiOptionEditorDraggableList extends GuiOptionEditor {
     private String getExampleText(Object forObject) {
         if (dynamicToString) {
             try {
-                return forObject != null ? forObject.toString() : "";
-            } catch (Exception e) { return ""; }
+                return forObject != null ? forObject.toString() : "<null>";
+            } catch (Exception e) {
+                return "<unknown " + forObject + ">";
+            }
         } else {
             String str = exampleText.get(forObject);
-            if (str == null) { str = ""; }
+            if (str == null) {
+                str = "<unknown " + forObject + ">";
+                Warnings.warnOnce(
+                    "Could not find draggable list object for " + forObject +
+                        " on option " + option.getDebugDeclarationLocation(),
+                    forObject, option
+                );
+            }
             return str;
         }
     }

--- a/common/src/main/java/io/github/notenoughupdates/moulconfig/processor/BuiltinMoulConfigGuis.java
+++ b/common/src/main/java/io/github/notenoughupdates/moulconfig/processor/BuiltinMoulConfigGuis.java
@@ -52,7 +52,7 @@ public class BuiltinMoulConfigGuis {
         processor.registerConfigEditor(ConfigEditorText.class, (processedOption, configEditorText) ->
             new GuiOptionEditorText(processedOption));
         processor.registerConfigEditor(ConfigEditorDraggableList.class, (processedOption, configEditorDraggableList) ->
-            new GuiOptionEditorDraggableList(processedOption, configEditorDraggableList.exampleText(), configEditorDraggableList.allowDeleting(), configEditorDraggableList.requireNonEmpty()));
+            new GuiOptionEditorDraggableList(processedOption, configEditorDraggableList.exampleText(), configEditorDraggableList.allowDeleting(), configEditorDraggableList.dynamicToString(), configEditorDraggableList.requireNonEmpty()));
 
         processor.registerConfigEditor(ConfigLink.class, ((option, configLink) -> {
             Field field;


### PR DESCRIPTION
Adds an annotation parameter to `ConfigEditorDraggableList` to specify that it should evaluate `toString()` of the objects at-render time rather than