### PR TITLE
Fix colour picker issues on 1.21.5

### DIFF
--- a/common/src/main/java/io/github/notenoughupdates/moulconfig/gui/component/ColorSelectComponent.java
+++ b/common/src/main/java/io/github/notenoughupdates/moulconfig/gui/component/ColorSelectComponent.java
@@ -141,10 +141,8 @@ public class ColorSelectComponent extends GuiComponent {
     private static DynamicTextureReference opacitySliderRef;
 
     private static DynamicTextureReference loadOrUpdate(RenderContext renderContext, DynamicTextureReference ref, BufferedImage image) {
-        if (ref == null)
-            return renderContext.generateDynamicTexture(image);
-        ref.update(image);
-        return ref;
+        if (ref != null) ref.destroy();
+        return renderContext.generateDynamicTexture(image);
     }
 
     private DynamicTextureReference getOpacitySlider(RenderContext renderContext, int currentColour) {

--- a/common/src/main/java/io/github/notenoughupdates/moulconfig/gui/editors/GuiOptionEditorColour.java
+++ b/common/src/main/java/io/github/notenoughupdates/moulconfig/gui/editors/GuiOptionEditorColour.java
@@ -74,9 +74,20 @@ public class GuiOptionEditorColour extends ComponentEditor {
                 if (mouseEvent instanceof MouseEvent.Click) {
                     val click = ((MouseEvent.Click) mouseEvent);
                     if (click.getMouseState() && click.getMouseButton() == 0 && context.isHovered()) {
-                        openOverlay(new ColorSelectComponent(0, 0, get().toLegacyString(), newString -> set(newString), () -> {
+                        ColorSelectComponent colorSelectComponent = new ColorSelectComponent(0, 0, get().toLegacyString(), newString -> set(newString), () -> {
                             closeOverlay();
-                        }), context.getAbsoluteMouseX(), context.getAbsoluteMouseY());
+                        });
+                        //Clamp the Y so that the colour picker can't go off screen
+                        int scaledHeight = context.getRenderContext().getMinecraft().getScaledHeight();
+				        int clampedY;
+
+				        if (context.getAbsoluteMouseY() + colorSelectComponent.getHeight() > scaledHeight) {
+					        clampedY = scaledHeight - colorSelectComponent.getHeight();
+				        } else {
+					        clampedY = context.getAbsoluteMouseY();
+				        }
+
+                        openOverlay(colorSelectComponent, context.getAbsoluteMouseX(), clampedY);
                         return true;
                     }
                 }

--- a/modern/1.21.5/src/main/kotlin/io/github/notenoughupdates/moulconfig/platform/ModernRenderContext.kt
+++ b/modern/1.21.5/src/main/kotlin/io/github/notenoughupdates/moulconfig/platform/ModernRenderContext.kt
@@ -211,13 +211,13 @@ class ModernRenderContext(val drawContext: DrawContext) : RenderContext {
                 if (hasDepth) RenderLayer.getGuiTextured(texture)
                 else RenderLayer.getGuiTexturedOverlay(texture))
             bufferBuilder.vertex(matrix4f, x, y, 0F).texture(u1, v1)
-                .color(tintA, tintG, tintB, tintA).next()
+                .color(tintR, tintG, tintB, tintA).next()
             bufferBuilder.vertex(matrix4f, x, y + height, 0f).texture(u1, v2)
-                .color(tintA, tintG, tintB, tintA).next()
+                .color(tintR, tintG, tintB, tintA).next()
             bufferBuilder.vertex(matrix4f, x + width, y + height, 0f).texture(u2, v2)
-                .color(tintA, tintG, tintB, tintA).next()
+                .color(tintR, tintG, tintB, tintA).next()
             bufferBuilder.vertex(matrix4f, x + width, y, 0F).texture(u2, v1)
-                .color(tintA, tintG, tintB, tintA).next()
+                .color(tintR, tintG, tintB, tintA).next()
         }
     }
 


### PR DESCRIPTION
- Fixes the red channel being swapped for the alpha channel when rendering a textured rectangle
- Fixes the colour wheel textures not updating
  - Not sure why using a new texture each time "fixes" it but it at least works correctly this way.
- Clamp the Y of the colour picker to prevent it going off screen
  - More of an issue on higher GUI scales

Closes #52