### PR TITLE
Text field improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build/
 .gradle/
 .env
 *.png~
+*.DS_Store

--- a/common/src/main/java/io/github/notenoughupdates/moulconfig/common/IKeyboardConstants.kt
+++ b/common/src/main/java/io/github/notenoughupdates/moulconfig/common/IKeyboardConstants.kt
@@ -9,6 +9,8 @@ interface IKeyboardConstants {
     val backSpace: Int
     val ctrlLeft: Int
     val ctrlRight: Int
+    val cmdLeft: Int
+    val cmdRight: Int
     val shiftLeft: Int
     val shiftRight: Int
     val escape: Int

--- a/common/src/main/java/io/github/notenoughupdates/moulconfig/common/IMinecraft.kt
+++ b/common/src/main/java/io/github/notenoughupdates/moulconfig/common/IMinecraft.kt
@@ -30,6 +30,7 @@ interface IMinecraft {
     val scaledWidth: Int
     val scaledHeight: Int
     val scaleFactor: Int
+    val isOnMacOS: Boolean
     fun isMouseButtonDown(mouseButton: Int): Boolean
     fun isKeyboardKeyDown(keyboardKey: Int): Boolean
 

--- a/common/src/main/java/io/github/notenoughupdates/moulconfig/common/RenderContext.java
+++ b/common/src/main/java/io/github/notenoughupdates/moulconfig/common/RenderContext.java
@@ -27,8 +27,15 @@ public interface RenderContext {
         return isKeyboardKeyDown(KeyboardConstants.INSTANCE.getShiftLeft()) || isKeyboardKeyDown(KeyboardConstants.INSTANCE.getShiftRight());
     }
 
+    /**
+     * Returns whether the control key is held down on Windows and Linux, and for macOS checks if the command key is held down.
+     */
     default boolean isCtrlDown() {
-        return isKeyboardKeyDown(KeyboardConstants.INSTANCE.getCtrlLeft()) || isKeyboardKeyDown(KeyboardConstants.INSTANCE.getCtrlRight());
+        if (getMinecraft().isOnMacOS()) {
+            return isKeyboardKeyDown(KeyboardConstants.INSTANCE.getCmdLeft()) || isKeyboardKeyDown(KeyboardConstants.INSTANCE.getCmdRight());
+        } else {
+            return isKeyboardKeyDown(KeyboardConstants.INSTANCE.getCtrlLeft()) || isKeyboardKeyDown(KeyboardConstants.INSTANCE.getCtrlRight());
+        }
     }
 
     default void drawStringScaledMaxWidth(@NotNull String text, @NotNull IFontRenderer fontRenderer, int x, int y, boolean shadow, int width, int color) {

--- a/common/src/main/java/io/github/notenoughupdates/moulconfig/gui/component/TextFieldComponent.kt
+++ b/common/src/main/java/io/github/notenoughupdates/moulconfig/gui/component/TextFieldComponent.kt
@@ -25,6 +25,7 @@ open class TextFieldComponent(
     private var scrollOffset = 0
     private var visibleText: String? = null
     private var shouldExpandToFit = false
+    private var initializedCursor = false
     override fun getWidth(): Int {
         if (isFocused && shouldExpandToFit) return max(preferredWidth, font.getStringWidth(text.get()) + 10)
         return preferredWidth
@@ -253,6 +254,16 @@ open class TextFieldComponent(
         if (mouseEvent is Click && mouseEvent.mouseState) {
             if (context.isHovered) {
                 requestFocus()
+
+                //Initializes the position of the cursor to the end of the text in the box when its first clicked on
+                if (!initializedCursor) {
+                    initializedCursor = true
+                    //The validate method clamps it to the end of the text for us
+                    cursor = Int.MAX_VALUE
+                    validateCursor()
+                    scrollCursorIntoView(context.width)
+                }
+
                 return true
             } else {
                 setFocus(false)

--- a/legacy/src/main/java/io/github/notenoughupdates/moulconfig/internal/ForgeKeyboardConstants.kt
+++ b/legacy/src/main/java/io/github/notenoughupdates/moulconfig/internal/ForgeKeyboardConstants.kt
@@ -10,6 +10,10 @@ object ForgeKeyboardConstants : IKeyboardConstants {
         get() = Keyboard.KEY_LCONTROL
     override val ctrlRight: Int
         get() = Keyboard.KEY_RCONTROL
+    override val cmdLeft: Int
+        get() = Keyboard.KEY_LMETA
+    override val cmdRight: Int
+        get() = Keyboard.KEY_RMETA
     override val shiftLeft: Int
         get() = Keyboard.KEY_LSHIFT
     override val shiftRight: Int

--- a/legacy/src/main/java/io/github/notenoughupdates/moulconfig/internal/ForgeMinecraft.kt
+++ b/legacy/src/main/java/io/github/notenoughupdates/moulconfig/internal/ForgeMinecraft.kt
@@ -207,6 +207,9 @@ class ForgeMinecraft : IMinecraft {
         }
     }
 
+    override val isOnMacOS: Boolean
+        get() = Minecraft.isRunningOnMac
+
     override val defaultFontRenderer: IFontRenderer
         get() = ForgeFontRenderer(Minecraft.getMinecraft().fontRendererObj)
     override val keyboardConstants: IKeyboardConstants

--- a/modern/1.21.4/src/main/kotlin/io/github/notenoughupdates/moulconfig/platform/MoulConfigPlatform.kt
+++ b/modern/1.21.4/src/main/kotlin/io/github/notenoughupdates/moulconfig/platform/MoulConfigPlatform.kt
@@ -118,6 +118,9 @@ class MoulConfigPlatform : IMinecraft {
             return window.scaleFactor.toInt()
         }
 
+    override val isOnMacOS: Boolean
+        get() = MinecraftClient.IS_SYSTEM_MAC
+
     override fun isMouseButtonDown(mouseButton: Int): Boolean {
         return GLFW.glfwGetMouseButton(window.handle, mouseButton) == GLFW.GLFW_PRESS
     }

--- a/modern/1.21.5/src/main/kotlin/io/github/notenoughupdates/moulconfig/platform/MoulConfigPlatform.kt
+++ b/modern/1.21.5/src/main/kotlin/io/github/notenoughupdates/moulconfig/platform/MoulConfigPlatform.kt
@@ -119,6 +119,9 @@ class MoulConfigPlatform : IMinecraft {
             return window.scaleFactor.toInt()
         }
 
+    override val isOnMacOS: Boolean
+        get() = MinecraftClient.IS_SYSTEM_MAC
+
     override fun isMouseButtonDown(mouseButton: Int): Boolean {
         return GLFW.glfwGetMouseButton(window.handle, mouseButton) == GLFW.GLFW_PRESS
     }

--- a/modern/templates/kotlin/platform/ModernKeyboardConstants.kt
+++ b/modern/templates/kotlin/platform/ModernKeyboardConstants.kt
@@ -10,6 +10,10 @@ object ModernKeyboardConstants : IKeyboardConstants {
         get() = InputUtil.GLFW_KEY_LEFT_CONTROL
     override val ctrlRight: Int
         get() = InputUtil.GLFW_KEY_RIGHT_CONTROL
+    override val cmdLeft: Int
+        get() = InputUtil.GLFW_KEY_LEFT_SUPER
+    override val cmdRight: Int
+        get() = InputUtil.GLFW_KEY_RIGHT_SUPER
     override val shiftLeft: Int
         get() = InputUtil.GLFW_KEY_LEFT_SHIFT
     override val shiftRight: Int


### PR DESCRIPTION
- Makes the text input field cursor start at the end when clicking on it for the first time
  - Improves interacting with them when there is a lot of text in there/makes a bit more sense imo.
- Fixes checking for control instead of command on macOS
  - The forge keyboard constants should be right but I haven't worked with it at all so you might wanna check.
- Also adds a gitignore for .DS_Store files that macOS generates