### PR TITLE
Dropdown improvements

### DIFF
--- a/common/src/main/java/io/github/notenoughupdates/moulconfig/gui/editors/GuiOptionEditorDropdown.java
+++ b/common/src/main/java/io/github/notenoughupdates/moulconfig/gui/editors/GuiOptionEditorDropdown.java
@@ -175,7 +175,17 @@ public class GuiOptionEditorDropdown extends ComponentEditor {
             if (mouseEvent instanceof MouseEvent.Click && ((MouseEvent.Click) mouseEvent).getMouseState() && context.isHovered()) {
                 if (!isOverlayOpen()) {
                     componentWidth = context.getWidth();
-                    openOverlay(dropdownOverlay, context.getRenderOffsetX(), context.getRenderOffsetY());
+                    //Clamp the Y so that the dropdown can't go off the screen
+                    int scaledHeight = context.getRenderContext().getMinecraft().getScaledHeight();
+                    int clampedY;
+
+                    if (context.getRenderOffsetY() + dropdownOverlay.getHeight() > scaledHeight) {
+                        clampedY = scaledHeight - dropdownOverlay.getHeight();
+                    } else {
+                        clampedY = context.getRenderOffsetY();
+                    }
+
+                    openOverlay(dropdownOverlay, context.getRenderOffsetX(), clampedY);
                 }
                 return true;
             }

--- a/common/src/main/java/io/github/notenoughupdates/moulconfig/gui/editors/GuiOptionEditorDropdown.java
+++ b/common/src/main/java/io/github/notenoughupdates/moulconfig/gui/editors/GuiOptionEditorDropdown.java
@@ -37,17 +37,27 @@ public class GuiOptionEditorDropdown extends ComponentEditor {
     private Enum<?>[] constants;
     private String valuesForSearch;
 
+    public GuiOptionEditorDropdown(ProcessedOption option, String[] values) {
+        this(option, values, false);
+    }
+
     public GuiOptionEditorDropdown(
         ProcessedOption option,
-        String[] values
+        String[] values,
+        boolean forceGivenValues
     ) {
         super(option);
         Class<?> clazz = (Class<?>) option.getType();
         if (Enum.class.isAssignableFrom(clazz)) {
             constants = (Enum<?>[]) (clazz).getEnumConstants();
-            this.values = new String[constants.length];
-            for (int i = 0; i < constants.length; i++) {
-                this.values[i] = constants[i].toString();
+            if (forceGivenValues) {
+                assert values.length == constants.length;
+                this.values = values;
+            } else {
+                this.values = new String[constants.length];
+                for (int i = 0; i < constants.length; i++) {
+                    this.values[i] = constants[i].toString();;
+                }
             }
         } else {
             this.values = values;


### PR DESCRIPTION
- Allow forcing the use of the `values` array when using an enum with a new constructor parameter (the old constructor has been preserved and defaults this to false).
  - This is useful for when you want to override the names of an enum for which you do not control the `toString` result (e.g. vanilla enums).
- Clamps the position of drop-downs to prevent them going off screen
  - It would probably be best if the openOverlay method was changed to do this automatically (maybe future PR)