### PR TITLE
fix category colours on 1.8

### DIFF
--- a/common/src/main/java/io/github/notenoughupdates/moulconfig/common/text/DefaultFormattingColour.java
+++ b/common/src/main/java/io/github/notenoughupdates/moulconfig/common/text/DefaultFormattingColour.java
@@ -57,8 +57,10 @@ public enum DefaultFormattingColour {
                 MathUtil.squaredDistance(cr, r)
                     + MathUtil.squaredDistance(cg, g)
                     + MathUtil.squaredDistance(cb, b);
-            if (sqDist < minDistance)
+            if (sqDist < minDistance) {
                 best = candidate;
+                minDistance = sqDist;
+            }
         }
         assert best != null;
         return best;

--- a/modern/templates/java/io/github/notenoughupdates/moulconfig/test/InnerCategory.kt
+++ b/modern/templates/java/io/github/notenoughupdates/moulconfig/test/InnerCategory.kt
@@ -1,0 +1,12 @@
+package io.github.notenoughupdates.moulconfig.test
+
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
+import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
+
+class InnerCategory {
+
+    @ConfigEditorBoolean
+    @ConfigOption(name = "Test Option", desc = "Test toggle")
+    var shouldTestToggle: Boolean = false
+
+}

--- a/modern/templates/java/io/github/notenoughupdates/moulconfig/test/TestCategoryB.kt
+++ b/modern/templates/java/io/github/notenoughupdates/moulconfig/test/TestCategoryB.kt
@@ -1,0 +1,10 @@
+package io.github.notenoughupdates.moulconfig.test
+
+import io.github.notenoughupdates.moulconfig.annotations.Category
+
+class TestCategoryB {
+
+    @Category(name = "Test Inner Category", desc = "")
+    var innerCategory: InnerCategory = InnerCategory()
+
+}

--- a/modern/templates/java/io/github/notenoughupdates/moulconfig/test/TestConfig.kt
+++ b/modern/templates/java/io/github/notenoughupdates/moulconfig/test/TestConfig.kt
@@ -12,6 +12,10 @@ class TestConfig : Config() {
     override fun isValidRunnable(runnableId: Int): Boolean {
         return false
     }
+
     @Category(name = "Cat a", desc = "Cat a desc")
     var testCategoryA: TestCategoryA = TestCategoryA()
+
+    @Category(name = "Cat b", desc = "Cat b desc")
+    var testCategoryB: TestCategoryB = TestCategoryB()
 }


### PR DESCRIPTION
Fix colours in the left of the config on 1.8

<img width="310" height="140" alt="image" src="https://github.com/user-attachments/assets/79fbf894-43d4-4e7c-b1ce-fff23a2cee07" />

I also went and made some test categories on modern so that I could test it all looked the same.