### PR TITLE
Fix mouse position calculations for < 1.21.11

### DIFF
--- a/modern/templates/java/io/github/notenoughupdates/moulconfig/platform/MoulConfigPlatform.java
+++ b/modern/templates/java/io/github/notenoughupdates/moulconfig/platform/MoulConfigPlatform.java
@@ -179,8 +179,8 @@ public class MoulConfigPlatform implements IMinecraft {
         var mouse = mc.mouseHandler;
         var window = mc.getWindow();
         #if MC < 12111
-        var x = (mouse.xpos() * (double) window.getGuiScaledWidth() / window.getWidth());
-        var y = (mouse.ypos() * (double) window.getGuiScaledHeight() / window.getHeight());
+        var x = (mouse.xpos() * (double) window.getGuiScaledWidth() / window.getScreenWidth());
+        var y = (mouse.ypos() * (double) window.getGuiScaledHeight() / window.getScreenHeight());
         #else
         double x = mouse.getScaledXPos(window);
         double y = mouse.getScaledYPos(window);


### PR DESCRIPTION
I believe this was a small mistake made when porting to Mojmap since the display’s dimensions may not match those of the frame buffer thus resulting in incorrect mouse positions when the two aren’t the same (which mostly notably occurs on macOS).