### PR TITLE
feat: add forbidden characters to @ConfigEditorText

### DIFF
--- a/common/src/main/java/io/github/notenoughupdates/moulconfig/annotations/ConfigEditorText.java
+++ b/common/src/main/java/io/github/notenoughupdates/moulconfig/annotations/ConfigEditorText.java
@@ -28,4 +28,8 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
 public @interface ConfigEditorText {
+    /**
+     * @return set forbidden characters as a string, e.g. "§z" for '§' and 'z' to disable them from being allowed to write inside the text field
+     */
+    String forbidden() default "§";
 }

--- a/common/src/main/java/io/github/notenoughupdates/moulconfig/gui/component/ColorSelectComponent.java
+++ b/common/src/main/java/io/github/notenoughupdates/moulconfig/gui/component/ColorSelectComponent.java
@@ -38,6 +38,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.awt.*;
 import java.awt.image.BufferedImage;
+import java.util.Collections;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.regex.Matcher;
@@ -77,7 +78,8 @@ public class ColorSelectComponent extends GuiComponent {
         48,
         GetSetter.constant(true),
         "#000000",
-        IMinecraft.INSTANCE.getDefaultFontRenderer()
+        IMinecraft.INSTANCE.getDefaultFontRenderer(),
+        Collections.singleton('§')
     );
 
     private int xSize = 119;

--- a/common/src/main/java/io/github/notenoughupdates/moulconfig/gui/component/TextFieldComponent.kt
+++ b/common/src/main/java/io/github/notenoughupdates/moulconfig/gui/component/TextFieldComponent.kt
@@ -232,12 +232,14 @@ open class TextFieldComponent(
             }
         } else if (event is KeyboardEvent.CharTyped) {
             val it = event.char
-            var anyWritten = false
-            if (it >= ' ' && it != '§' && it.code != 127) {
-                writeText(it + "", context.width)
-                anyWritten = true
-            }
-            return anyWritten
+
+            if (it < ' ' || it.code == 127) return false
+
+            // consume event, so we don't write into the searchbar the moment we type a forbidden char
+            if (forbiddenChars.contains(it)) return true
+
+            writeText(it + "", context.width)
+            return true
         } else {
             return false
         }
@@ -287,15 +289,22 @@ open class TextFieldComponent(
     }
 
     fun writeText(s: String, width: Int) {
+        val filteredString = s.filter { it !in forbiddenChars }
+
+        // we cancel if and only if the user tried to write / insert text, but everything got filtered out
+        // e.g. backspace delivers an empty string, thus should not be canceled
+        // -> only checking, if filteredString is empty is not sufficient (backspace = empty -> filtered = empty)
+        if (filteredString.isEmpty() && s.isNotEmpty()) return
+
         val t = text.get()
         if (selection == -1) {
-            text.set(safeSubString(t, 0, cursor) + s + safeSubString(t, cursor))
-            cursor += s.length
+            text.set(safeSubString(t, 0, cursor) + filteredString + safeSubString(t, cursor))
+            cursor += filteredString.length
         } else {
             val l = min(cursor, selection)
             val r = max(cursor, selection)
-            text.set(safeSubString(t, 0, l) + s + safeSubString(t, r))
-            cursor = l + s.length
+            text.set(safeSubString(t, 0, l) + filteredString + safeSubString(t, r))
+            cursor = l + filteredString.length
             selection = -1
         }
         scrollCursorIntoView(width)

--- a/common/src/main/java/io/github/notenoughupdates/moulconfig/gui/component/TextFieldComponent.kt
+++ b/common/src/main/java/io/github/notenoughupdates/moulconfig/gui/component/TextFieldComponent.kt
@@ -20,6 +20,7 @@ open class TextFieldComponent(
     val editable: Supplier<Boolean> = GetSetter.constant(true),
     val suggestion: String = "",
     val font: IFontRenderer = IMinecraft.INSTANCE.defaultFontRenderer,
+    val forbiddenChars: Set<Char> = setOf('§')
 ) : GuiComponent() {
     private var cursor = 0
     private var selection = -1

--- a/common/src/main/java/io/github/notenoughupdates/moulconfig/gui/editors/GuiOptionEditorText.java
+++ b/common/src/main/java/io/github/notenoughupdates/moulconfig/gui/editors/GuiOptionEditorText.java
@@ -10,11 +10,13 @@ import io.github.notenoughupdates.moulconfig.observer.GetSetter;
 import io.github.notenoughupdates.moulconfig.processor.ProcessedOption;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.stream.Collectors;
+
 public class GuiOptionEditorText extends ComponentEditor {
 
     GuiComponent component;
 
-    public GuiOptionEditorText(ProcessedOption option) {
+    public GuiOptionEditorText(ProcessedOption option, String forbidden) {
         super(option);
 
         if (option.getType() != String.class) {

--- a/common/src/main/java/io/github/notenoughupdates/moulconfig/gui/editors/GuiOptionEditorText.java
+++ b/common/src/main/java/io/github/notenoughupdates/moulconfig/gui/editors/GuiOptionEditorText.java
@@ -10,14 +10,20 @@ import io.github.notenoughupdates.moulconfig.observer.GetSetter;
 import io.github.notenoughupdates.moulconfig.processor.ProcessedOption;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class GuiOptionEditorText extends ComponentEditor {
 
     GuiComponent component;
+    private final Set<Character> forbiddenChars;
 
     public GuiOptionEditorText(ProcessedOption option, String forbidden) {
         super(option);
+
+        this.forbiddenChars = forbidden.chars()
+            .mapToObj(c -> (char) c)
+            .collect(Collectors.toSet());
 
         if (option.getType() != String.class) {
             Warnings.warn("@ConfigEditorText " + option.getDebugDeclarationLocation() + " is not a string option.");
@@ -32,7 +38,8 @@ public class GuiOptionEditorText extends ComponentEditor {
                 80,
                 GetSetter.constant(true),
                 "",
-                IMinecraft.INSTANCE.getDefaultFontRenderer()
+                IMinecraft.INSTANCE.getDefaultFontRenderer(),
+                forbiddenChars
             ));
         }
         return component;

--- a/common/src/main/java/io/github/notenoughupdates/moulconfig/processor/BuiltinMoulConfigGuis.java
+++ b/common/src/main/java/io/github/notenoughupdates/moulconfig/processor/BuiltinMoulConfigGuis.java
@@ -51,7 +51,7 @@ public class BuiltinMoulConfigGuis {
         processor.registerConfigEditor(ConfigEditorInfoText.class, (processedOption, configEditorInfoText) ->
             new GuiOptionEditorInfoText(processedOption, StructuredText.of(configEditorInfoText.infoTitle())));
         processor.registerConfigEditor(ConfigEditorText.class, (processedOption, configEditorText) ->
-            new GuiOptionEditorText(processedOption));
+            new GuiOptionEditorText(processedOption, configEditorText.forbidden()));
         processor.registerConfigEditor(ConfigEditorDraggableList.class, (processedOption, configEditorDraggableList) ->
             new GuiOptionEditorDraggableList(processedOption, configEditorDraggableList.exampleText(), configEditorDraggableList.allowDeleting(), configEditorDraggableList.requireNonEmpty()));
 

--- a/modern/templates/java/io/github/notenoughupdates/moulconfig/test/TestCategoryA.kt
+++ b/modern/templates/java/io/github/notenoughupdates/moulconfig/test/TestCategoryA.kt
@@ -78,7 +78,7 @@ class TestCategoryA {
     var notice: String = ""
 
     @ConfigOption(name = "Text Box", desc = "Lets you put strings.")
-    @ConfigEditorText
+    @ConfigEditorText(forbidden = "§z")
     var customText: Property<String> = Property.of("abc")
 
     @ConfigOption(name = "Draggable List", desc = "§eDrag text to change the order of the list.")


### PR DESCRIPTION
## Summary

the problem:
while coding myself i noticed that the `@ConfigEditorText` annotation does check for the presence of a '§' within the textfield and blocks it accordingly, but only if it was typed by hand. if it is pasted, the clipboard content simply gets written as it is.

you can see the behavior in `TextFieldComponent`:
```kotlin
// ...
KeyboardConstants.keyV -> if (context.renderContext.isLogicalCtrlDown) {
    writeText(IMinecraft.INSTANCE.copyFromClipboard(), context.width)
    return true
}
// ...
```

that means, if we would like to copy a '§' and paste it inside of a textfield it would just get placed and you can use color codes inside of the textfield.
<p align="center">
    <img width="927" height="170" alt="image" src="https://github.com/user-attachments/assets/5c0d6b00-77c5-471b-8550-5bb346c42751" />
    <br>
    <em> Figure 1: Example of Color Codes inside a TextField </em>
</p>

this behavior is not intended, as it could potentially cause bugs, if we would like to read from our text variable, where the content gets stored and build something off of that (e.g. we want to write the content of the textfield in the chat).

therefore i added `forbidden` as a parameter to `@ConfigEditorText`.

```java
public @interface ConfigEditorText {
    /**
     * @return set forbidden characters as a string, e.g. "§z" for '§' and 'z' to disable them from being allowed to write inside the text field
     */
    String forbidden() default "§";
}
```

its purpose is to block any given characters from being pasted in the textfield.
following i modified the `writeText` method in `TextFieldComponent` as follows:

```kotlin
fun writeText(s: String, width: Int) {
    val filteredString = s.filter { it !in forbiddenChars }

    if (filteredString.isEmpty() && s.isNotEmpty()) return
    // ...
}
```

we filter the text, that's to be written and remove all forbidden characters. if the string is empty after filtering, we just cancel the event. there is an exception though, if we press backspace, the `writeText` method gets called with an empty string already, and thus we don't want to cancel the event (`s` has to be not empty, otherwise the `writeText` method proceeds).
after filtering we use `filteredString` to set our text, instead of `s`:
e.g.:
```kotlin
// prior:
text.set(safeSubString(t, 0, cursor) + s + safeSubString(t, cursor))

// after: 
text.set(safeSubString(t, 0, cursor) + filteredString + safeSubString(t, cursor))
```

this prevents pasting forbidden chars, but to prevent typing them i modified the `CharTyped` event branch as follows:

```kotlin
// ...
else if (event is KeyboardEvent.CharTyped) {
    val it = event.char

    if (it < ' ' || it.code == 127) return false

    // consume event, so we don't write into the searchbar the moment we type a forbidden char
    if (forbiddenChars.contains(it)) return true

    writeText(it + "", context.width)
    return true
} else {
    return false
}
```

i consciously consume the event, if we type a forbidden character, so we don't always focus the searchbar, as soon as we type one. we just stay inside of the textfield.
i removed the hardcoded version of the previously cancellation of the '§' character:
```kotlin
// ...
if (it >= ' ' && it != '§' && it.code != 127) {
    writeText(it + "", context.width)
    anyWritten = true
}
// ...
```

and replaced it with the standard forbidden character (which gets checked as well by default):

```java
String forbidden() default "§";
```

now the user has the option to set forbidden character itself, and the standard forbidden one is *really* forbidden.

to present this i added to the `TestCategoryA`:

```kotlin
// ...
@ConfigOption(name = "Text Box", desc = "Lets you put strings.")
@ConfigEditorText(forbidden = "§z")
var customText: Property<String> = Property.of("abc")
// ...
```

the forbidden character '§' and 'z'. 
notice, that when you set forbidden character yourself, the default one ('§') gets overridden and is not forbidden anymore by default. (you have to add it manually again, if still needed).