### PR TITLE
feat: Add scroll support to DraggableList dropdown

### DIFF
--- a/common/src/main/java/io/github/notenoughupdates/moulconfig/gui/MoulConfigEditor.java
+++ b/common/src/main/java/io/github/notenoughupdates/moulconfig/gui/MoulConfigEditor.java
@@ -835,8 +835,50 @@ public class MoulConfigEditor<T extends Config> extends GuiElement implements Cl
             }
         }
 
+        boolean overlayConsumedScroll = false;
+        if (mouseEvent instanceof MouseEvent.Scroll) {
+            int optionY = -optionsScroll.getValue();
+            if (getSelectedCategory() != null && getCurrentlyVisibleCategories() != null &&
+                getCurrentlyVisibleCategories().containsKey(getSelectedCategory())) {
+                int optionWidthDefault = optsInnerRight - optsInnerLeft - 20;
+                ProcessedCategory cat = getCurrentlyVisibleCategories().get(getSelectedCategory());
+                HashMap<Integer, Integer> activeAccordions = new HashMap<>();
+                for (ProcessedOption option : getOptionsInCategory(cat)) {
+                    int optionWidth = optionWidthDefault;
+                    if (option.getAccordionId() >= 0) {
+                        if (!activeAccordions.containsKey(option.getAccordionId())) continue;
+                        int accordionDepth = activeAccordions.get(option.getAccordionId());
+                        optionWidth = optionWidthDefault - (2 * innerPadding) * (accordionDepth + 1);
+                    }
+                    GuiOptionEditor editor = option.getEditor();
+                    if (editor == null) continue;
+                    editor.setGuiContext(guiContext);
+                    if (editor instanceof GuiOptionEditorAccordion) {
+                        GuiOptionEditorAccordion accordion = (GuiOptionEditorAccordion) editor;
+                        if (accordion.getToggled()) {
+                            int accordionDepth = 0;
+                            if (option.getAccordionId() >= 0) {
+                                accordionDepth = activeAccordions.get(option.getAccordionId()) + 1;
+                            }
+                            activeAccordions.put(accordion.getAccordionId(), accordionDepth);
+                        }
+                    }
+                    int finalX = (optsInnerLeft + optsInnerRight - optionWidth) / 2 - 5;
+                    int finalY = innerTop + 5 + optionY;
+                    int finalWidth = optionWidth;
+                    if (ContextAware.wrapErrorWithContext(editor, () -> editor.mouseInputOverlay(
+                        finalX, finalY, finalWidth, mouseX, mouseY, mouseEvent
+                    ))) {
+                        overlayConsumedScroll = true;
+                        break;
+                    }
+                    optionY += ContextAware.wrapErrorWithContext(editor, editor::getHeight) + 5;
+                }
+            }
+        }
+
         int dWheel = mouseEvent instanceof MouseEvent.Scroll ? ((int) ((MouseEvent.Scroll) mouseEvent).getDWheel()) : 0;
-        if (mouseY > innerTop && mouseY < innerBottom && dWheel != 0) {
+        if (!overlayConsumedScroll && mouseY > innerTop && mouseY < innerBottom && dWheel != 0) {
             if (dWheel < 0) {
                 dWheel = -1;
             }

--- a/common/src/main/java/io/github/notenoughupdates/moulconfig/gui/editors/GuiOptionEditorDraggableList.java
+++ b/common/src/main/java/io/github/notenoughupdates/moulconfig/gui/editors/GuiOptionEditorDraggableList.java
@@ -44,6 +44,9 @@ public class GuiOptionEditorDraggableList extends ComponentEditor {
     private List<Object> activeText;
     private final boolean requireNonEmpty;
     private int dragStartIndex = -1;
+    private static final int DROPDOWN_WIDTH = 100;
+    private static final int DROPDOWN_ITEM_HEIGHT = 12;
+    private static final int DROPDOWN_SCREEN_MARGIN = 4;
 
     private LerpingInteger2 trashAnimation = new LerpingInteger2(255, 3, 2);
     private Pair<Integer, Integer> lastListRenderPos = new Pair<>(0, 0);
@@ -118,7 +121,7 @@ public class GuiOptionEditorDraggableList extends ComponentEditor {
                             var pos = IMinecraft.INSTANCE.getMousePosition();
                             if (activeText.size() == exampleText.size())
                                 return;
-                            openOverlay(makeDropDownOverlay(), pos.getFirst(), pos.getSecond());
+                            openDropDownOverlay(pos.getFirst(), pos.getSecond());
                         }),
                         new SpacerComponent(GetSetter.constant(5), GetSetter.constant(0)),
                         new GuiComponent() {
@@ -330,35 +333,73 @@ public class GuiOptionEditorDraggableList extends ComponentEditor {
         saveChanges();
     }
 
-    GuiComponent makeDropDownOverlay() {
+    private List<Object> getRemainingDropDownEntries() {
+        List<Object> remaining = new ArrayList<>(exampleText.keySet());
+        remaining.removeAll(activeText);
+        return remaining;
+    }
+
+    private int getDropDownContentHeight() {
+        return Math.max(0, -1 + DROPDOWN_ITEM_HEIGHT * getRemainingDropDownEntries().size());
+    }
+
+    private int getDropDownVisibleHeight(int overlayY) {
+        int screenHeight = IMinecraft.INSTANCE.getScaledHeight();
+        int maxHeight = Math.max(DROPDOWN_ITEM_HEIGHT, screenHeight - overlayY - DROPDOWN_SCREEN_MARGIN);
+        return Math.min(getDropDownContentHeight(), maxHeight);
+    }
+
+    private void openDropDownOverlay(int mouseX, int mouseY) {
+        int screenHeight = IMinecraft.INSTANCE.getScaledHeight();
+        int screenWidth = IMinecraft.INSTANCE.getScaledWidth();
+        int contentHeight = getDropDownContentHeight();
+        int maxVisibleHeight = Math.max(DROPDOWN_ITEM_HEIGHT, screenHeight - DROPDOWN_SCREEN_MARGIN * 2);
+        int visibleHeight = Math.min(contentHeight, maxVisibleHeight);
+        int overlayX = Math.min(mouseX, screenWidth - DROPDOWN_WIDTH - DROPDOWN_SCREEN_MARGIN);
+        int overlayY = Math.min(mouseY, screenHeight - visibleHeight - DROPDOWN_SCREEN_MARGIN);
+        overlayX = Math.max(DROPDOWN_SCREEN_MARGIN, overlayX);
+        overlayY = Math.max(DROPDOWN_SCREEN_MARGIN, overlayY);
+        openOverlay(makeDropDownOverlay(overlayY), overlayX, overlayY);
+    }
+
+    GuiComponent makeDropDownOverlay(int overlayY) {
         return new GuiComponent() {
+            int scrollOffset;
 
             @Override
             public int getWidth() {
-                return 100; // TODO: dynamically decide on a size
+                return DROPDOWN_WIDTH;
             }
 
             @Override
             public int getHeight() {
-                List<Object> remaining = new ArrayList<>(exampleText.keySet());
-                remaining.removeAll(activeText);
-                return -1 + 12 * remaining.size();
+                return getDropDownVisibleHeight(overlayY);
             }
 
             @Override
             public boolean mouseEvent(@NotNull MouseEvent mouseEvent, @NotNull GuiImmediateContext context) {
+                int maxScrollOffset = Math.max(0, getDropDownContentHeight() - context.getHeight());
+                if (scrollOffset > maxScrollOffset) {
+                    scrollOffset = maxScrollOffset;
+                }
+                if (context.isHovered() && mouseEvent instanceof MouseEvent.Scroll) {
+                    scrollOffset = (int) Math.max(0, Math.min(
+                        scrollOffset - (((MouseEvent.Scroll) mouseEvent).getDWheel() * 15),
+                        maxScrollOffset
+                    ));
+                    return true;
+                }
                 if (mouseEvent instanceof MouseEvent.Click) {
                     var click = (MouseEvent.Click) mouseEvent;
                     if (click.getMouseState() && context.isHovered()) {
-                        List<Object> remaining = new ArrayList<>(exampleText.keySet());
-                        remaining.removeAll(activeText);
+                        List<Object> remaining = getRemainingDropDownEntries();
                         int dropdownY = -1;
                         for (Object indexObject : remaining) {
-                            if (context.translated(0, dropdownY + 3, context.getWidth(), 10).isHovered()) {
+                            if (context.translated(0, dropdownY + 3 - scrollOffset, context.getWidth(), 10).isHovered()) {
                                 activeText.add(indexObject);
                                 return true;
                             }
-                            dropdownY += 12;
+                            dropdownY += DROPDOWN_ITEM_HEIGHT;
                         }
                     } else if (click.getMouseState()) {
                         closeOverlay();
@@ -369,13 +410,16 @@ public class GuiOptionEditorDraggableList extends ComponentEditor {
 
             @Override
             public void render(@NotNull GuiImmediateContext context) {
-                List<Object> remaining = new ArrayList<>(exampleText.keySet());
-                remaining.removeAll(activeText);
+                List<Object> remaining = getRemainingDropDownEntries();
                 if (remaining.isEmpty()) {
                     closeOverlay();
                     return;
                 }
 
+                int maxScrollOffset = Math.max(0, getDropDownContentHeight() - context.getHeight());
+                if (scrollOffset > maxScrollOffset) {
+                    scrollOffset = maxScrollOffset;
+                }
 
                 int dropdownHeight = context.getHeight();
                 int dropdownWidth = context.getWidth();
@@ -383,18 +427,20 @@ public class GuiOptionEditorDraggableList extends ComponentEditor {
                 var renderContext = context.getRenderContext();
                 int main = 0xff202026;
                 int outline = 0xff404046;
-                renderContext.drawColoredRect(0, 0, 1, dropdownHeight, outline); //0
-                renderContext.drawColoredRect(1, 0, dropdownWidth, 1, outline); //0
-                renderContext.drawColoredRect(dropdownWidth - 1, 1, dropdownWidth, dropdownHeight, outline); //Right
-                renderContext.drawColoredRect(
-                    1,
-                    dropdownHeight - 1,
-                    dropdownWidth - 1,
-                    dropdownHeight,
-                    outline
-                ); //Bottom
-                renderContext.drawColoredRect(1, 1, dropdownWidth - 1, dropdownHeight - 1, main); //Middle
+                renderContext.drawColoredRect(0, 0, 1, dropdownHeight, outline);
+                renderContext.drawColoredRect(1, 0, dropdownWidth, 1, outline);
+                renderContext.drawColoredRect(dropdownWidth - 1, 1, dropdownWidth, dropdownHeight, outline);
+                renderContext.drawColoredRect(1, dropdownHeight - 1, dropdownWidth - 1, dropdownHeight, outline);
+                renderContext.drawColoredRect(1, 1, dropdownWidth - 1, dropdownHeight - 1, main);
 
+                renderContext.pushRawScissor(
+                    context.getRenderOffsetX() + 1,
+                    context.getRenderOffsetY() + 1,
+                    context.getRenderOffsetX() + dropdownWidth - 1,
+                    context.getRenderOffsetY() + dropdownHeight - 1
+                );
+                renderContext.pushMatrix();
+                renderContext.translate(0, -scrollOffset);
                 int dropdownY = -1;
                 for (Object indexObject : remaining) {
                     StructuredText str = getExampleText(indexObject);
@@ -404,7 +450,20 @@ public class GuiOptionEditorDraggableList extends ComponentEditor {
                     renderContext.drawStringScaledMaxWidth(fr.splitLines(str).get(0),
                         fr, 3, 3 + dropdownY, false, dropdownWidth - 6, 0xffa0a0a0
                     );
-                    dropdownY += 12;
+                    dropdownY += DROPDOWN_ITEM_HEIGHT;
+                }
+                renderContext.popMatrix();
+                renderContext.popScissor();
+                int contentHeight = getDropDownContentHeight();
+                if (contentHeight > dropdownHeight) {
+                    int scrollBarTrackTop = 1;
+                    int scrollBarTrackBottom = dropdownHeight - 1;
+                    int trackHeight = scrollBarTrackBottom - scrollBarTrackTop;
+                    int thumbHeight = Math.max(8, trackHeight * dropdownHeight / contentHeight);
+                    int thumbTop = scrollBarTrackTop + (int) ((trackHeight - thumbHeight) * (float) scrollOffset / (contentHeight - dropdownHeight));
+                    int scrollBarX = dropdownWidth - 3;
+                    renderContext.drawColoredRect(scrollBarX, scrollBarTrackTop, scrollBarX + 2, scrollBarTrackBottom, 0x44ffffff);
+                    renderContext.drawColoredRect(scrollBarX, thumbTop, scrollBarX + 2, thumbTop + thumbHeight, 0xaaaaaaaa);
                 }
             }
         };

--- a/modern/templates/java/io/github/notenoughupdates/moulconfig/test/TestCategoryA.kt
+++ b/modern/templates/java/io/github/notenoughupdates/moulconfig/test/TestCategoryA.kt
@@ -15,9 +15,10 @@ class TestCategoryA {
     @ConfigEditorInfoText(infoTitle = "Bottom option")
     var bottomOption: Boolean = false
 
-    @ConfigOption(name ="Open Wide", desc= "Use a wider config menu")
+    @ConfigOption(name = "Open Wide", desc = "Use a wider config menu")
     @ConfigEditorBoolean
     var isWide: Boolean = false
+
     @ConfigOption(name = "Test Option", desc = "Test toggle")
     @ConfigEditorBoolean
     var shouldTestToggle: Boolean = false
@@ -89,7 +90,102 @@ class TestCategoryA {
 
     @ConfigOption(name = "Draggable List", desc = "§eDrag text to change the order of the list.")
     @ConfigEditorDraggableList(
-        exampleText = ["abc", "dec", "blah", "surel it works really cool and great :))"]
+        exampleText = [
+            "abc", "dec", "blah", "surel it works really cool and great :))",
+            "Lorem ipsum semper",
+            "auctor neque vitae",
+            "tempus quam pellentesque",
+            "Turpis egestas maecenas",
+            "pharetra convallis posuere",
+            "Malesuada fames ac",
+            "turpis egestas maecenas",
+            "In cursus turpis",
+            "Gravida neque convallis",
+            "a cras semper",
+            "auctor neque vitae",
+            "Dui faucibus in",
+            "Consequat nisl vel",
+            "pretium lectus quam",
+            "id leo in",
+            "Eget est lorem",
+            "ipsum dolor sit",
+            "Enim facilisis gravida",
+            "neque convallis a",
+            "Non arcu risus",
+            "quis varius quam",
+            "Enim praesent elementum",
+            "facilisis leo vel",
+            "Elementum sagittis vitae",
+            "et leo duis",
+            "Nisi lacus sed",
+            "Id aliquet lectus",
+            "proin nibh nisl",
+            "Egestas sed sed",
+            "risus pretium quam",
+            "A iaculis at",
+            "erat pellentesque adipiscing",
+            "Etiam dignissim diam",
+            "quis enim lobortis",
+            "Lacus suspendisse faucibus",
+            "interdum posuere lorem",
+            "ipsum dolor sit",
+            "Mattis nunc sed",
+            "Eu lobortis elementum",
+            "nibh tellus molestie",
+            "Eget duis at",
+            "tellus at urna",
+            "Sagittis aliquam malesuada",
+            "bibendum arcu vitae",
+            "Felis imperdiet proin",
+            "fermentum leo vel",
+            "Sed sed risus",
+            "Sed risus pretium",
+            "quam vulputate dignissim",
+            "Fames ac turpis",
+            "egestas maecenas pharetra",
+            "Lobortis scelerisque fermentum",
+            "dui faucibus in",
+            "Aenean pharetra magna",
+            "ac placerat vestibulum",
+            "Aliquet sagittis id",
+            "Netus et malesuada",
+            "Habitant morbi tristique",
+            "Habitasse platea dictumst",
+            "Egestas sed sed",
+            "risus pretium quam",
+            "Amet consectetur adipiscing",
+            "elit ut aliquam",
+            "purus sit amet",
+            "Mauris commodo quis",
+            "imperdiet massa tincidunt",
+            "Arcu felis bibendum",
+            "ut tristique et",
+            "Blandit volutpat maecenas",
+            "volutpat blandit aliquam",
+            "Quisque sagittis purus",
+            "sit amet volutpat",
+            "Mattis vulputate enim",
+            "Sit amet facilisis",
+            "magna etiam tempor",
+            "Erat nam at",
+            "lectus urna duis",
+            "Sit amet est",
+            "Nunc pulvinar sapien",
+            "et ligula ullamcorper",
+            "malesuada proin libero",
+            "Amet justo donec",
+            "enim diam vulputate",
+            "Adipiscing vitae proin",
+            "sagittis nisl rhoncus",
+            "At ultrices mi",
+            "tempus imperdiet nulla",
+            "Fermentum odio eu",
+            "feugiat pretium nibh",
+            "Felis imperdiet proin",
+            "fermentum leo vel",
+            "Consequat ac felis",
+            "donec et odio",
+        ]
     )
     var draggableList: List<Int> = ArrayList(mutableListOf(0, 1, 2, 3))
 
@@ -131,17 +227,20 @@ class TestCategoryA {
     val runnable = Runnable {
         println("JRunnable working")
     }
+
     @Expose
     @ConfigOption(name = "Test Runnable", desc = "Test a kotlin.jvm.functions.Function0")
     @ConfigEditorButton(buttonText = "Click me")
     val kRunnable = {
         println("KFunction0 working")
     }
+
     @Expose
     @ConfigOption(name = "Test Runnable", desc = "Test a (ignored) runnable using runnableId to emit a test warning")
     @ConfigEditorButton(
         runnableId = 10,
-        buttonText = "Click me")
+        buttonText = "Click me"
+    )
     val runnableId = Unit
 
     @Expose


### PR DESCRIPTION
## Changes
Added scroll support to the DraggableList dropdown overlay. The dropdown now clamps its height to the available screen space, and items can be scrolled through using the mouse wheel.

## Problem
When the dropdown had many items (e.g. 30+ entries), items would go off screen and there was no way to scroll to see or select them.

## Changelog
- Added scroll support to the DraggableList dropdown